### PR TITLE
fix(locale): guard against chunk load failures with static fallback

### DIFF
--- a/src/data/locale.ts
+++ b/src/data/locale.ts
@@ -1,19 +1,24 @@
 import { Locale } from 'date-fns';
+import { enUS } from 'date-fns/locale/en-US';
 
 export async function resolveLocale(): Promise<Locale> {
   const userLocaleNames = navigator.languages;
 
   for (const localeName of userLocaleNames) {
-    switch (localeName) {
-      case 'en-US':
-        return (await import('date-fns/locale/en-US')).enUS;
-      case 'nb-NO':
-      case 'nb':
-        return (await import('date-fns/locale/nb')).nb;
-      case 'vi':
-        return (await import('date-fns/locale/vi')).vi;
+    try {
+      switch (localeName) {
+        case 'en-US':
+          return enUS;
+        case 'nb-NO':
+        case 'nb':
+          return (await import('date-fns/locale/nb')).nb;
+        case 'vi':
+          return (await import('date-fns/locale/vi')).vi;
+      }
+    } catch {
+      return enUS;
     }
   }
 
-  return (await import('date-fns/locale/en-US')).enUS;
+  return enUS;
 }


### PR DESCRIPTION
Dynamic imports in resolveLocale() create separate JS chunks that must
be fetched over the network at runtime. If any fetch fails (transient
network error, deployment issue), the unhandled rejection propagates
through SWR and is thrown to the Sentry ErrorBoundary, showing the
user "Error! 😞".

Fix by:
- Importing enUS statically so the fallback is always bundled and
  never depends on a network request
- Wrapping dynamic imports in try/catch to return the static fallback
  on any chunk load failure instead of crashing