### PR TITLE
Add Guide page with visual examples and new-user badge

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,14 +8,25 @@ import { resolveTranslations } from '@/data/i18n';
 import { resolveLocale } from '@/data/locale';
 import { resolveSettings } from '@/data/settings';
 import { Calendar } from '@/pages/Calendar';
+import { Guide } from '@/pages/Guide';
 import { Settings } from '@/pages/Settings';
 
 const version = import.meta.env.VITE_APP_VERSION ?? 'Unspecified';
 
 const CHUNK_RELOAD_KEY = 'chunk-reload-attempted';
+const GUIDE_VISITED_KEY = 'guide-visited';
 
 export function App() {
-  const [page, setPage] = useState<'calendar' | 'settings'>('calendar');
+  const [page, setPage] = useState<'calendar' | 'settings' | 'guide'>('calendar');
+  const [guideVisited, setGuideVisited] = useState(() => localStorage.getItem(GUIDE_VISITED_KEY) === 'true');
+
+  const navigateToGuide = () => {
+    if (!guideVisited) {
+      localStorage.setItem(GUIDE_VISITED_KEY, 'true');
+      setGuideVisited(true);
+    }
+    setPage('guide');
+  };
   const { data: settings } = useSWR('settings', resolveSettings);
   const { data: locale } = useSWR(
     settings != null ? ['locale', settings.locale] : null,
@@ -39,6 +50,7 @@ export function App() {
         >
           {page === 'calendar' && <Calendar />}
           {page === 'settings' && <Settings />}
+          {page === 'guide' && <Guide t={t} />}
         </Sentry.ErrorBoundary>
       </main>
       <aside className="fixed left-0 bottom-0 w-dvw">
@@ -48,6 +60,9 @@ export function App() {
           </Tab>
           <Tab active={page === 'settings'} onClick={() => setPage('settings')}>
             {t.nav.settings}
+          </Tab>
+          <Tab active={page === 'guide'} badge={!guideVisited} onClick={navigateToGuide}>
+            {t.nav.guide}
           </Tab>
         </nav>
       </aside>
@@ -64,22 +79,26 @@ export function App() {
 
 type TabProps = {
   active: boolean;
+  badge?: boolean;
   children: ComponentProps<'button'>['children'];
   onClick: () => void;
 };
 
-function Tab({ active, children, onClick }: TabProps) {
+function Tab({ active, badge, children, onClick }: TabProps) {
   return (
     <button
       aria-current={active ? 'page' : undefined}
       className={classNames(
-        'flex-1 border border-(--border) hover:bg-(--surface)',
+        'relative flex-1 border border-(--border) hover:bg-(--surface)',
         active ? 'bg-(--surface)' : 'bg-white',
       )}
       style={{ height: 'min(80px, max(15vw, 15vh))' }}
       onClick={onClick}
     >
       {children}
+      {badge && (
+        <span aria-hidden="true" className="absolute top-[0.4em] right-[0.4em] w-[0.5em] h-[0.5em] rounded-full bg-(--vegetarian)" />
+      )}
     </button>
   );
 }

--- a/src/components/DayCellView.tsx
+++ b/src/components/DayCellView.tsx
@@ -1,0 +1,30 @@
+import classNames from 'classnames';
+
+type DayCellViewProps = {
+  lunarDay: number;
+  solarDay: number;
+  isToday?: boolean;
+  isVegetarian?: boolean;
+  faded?: boolean;
+  'aria-label'?: string;
+};
+
+export function DayCellView({ lunarDay, solarDay, isToday, isVegetarian, faded, 'aria-label': ariaLabel }: DayCellViewProps) {
+  return (
+    <div className={classNames('flex justify-center', faded && 'opacity-[0.5]')}>
+      <div
+        aria-label={ariaLabel}
+        className={classNames(
+          'relative flex flex-col justify-center items-center w-[2.2em] h-[2.2em]',
+          isToday && !isVegetarian && 'bg-(--foreground) rounded-full font-bold text-(--background)',
+          isToday && isVegetarian && 'bg-(--vegetarian) rounded-full font-bold text-(--background)',
+          isVegetarian && !isToday && 'text-(--vegetarian) font-bold',
+        )}
+      >
+        {isVegetarian && <span aria-hidden="true" className="absolute top-[0.3em] text-[0.3em] leading-none">•</span>}
+        <span className="text-[0.5em] leading-none">{lunarDay}</span>
+        <span className="leading-none">{solarDay}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/data/i18n.ts
+++ b/src/data/i18n.ts
@@ -8,6 +8,7 @@ export type Translations = {
     ariaLabel: string;
     calendar: string;
     settings: string;
+    guide: string;
   };
   calendar: {
     previousMonth: string;
@@ -24,6 +25,19 @@ export type Translations = {
     vegetarianPractice: string;
   };
   practices: readonly [string, string, string, string, string];
+  guide: {
+    heading: string;
+    description: string;
+    howToRead: string;
+    examples: {
+      regular: string;
+      vegetarian: string;
+      todayNormal: string;
+      todayVegetarian: string;
+      otherMonth: string;
+    };
+    settingsNote: string;
+  };
 };
 
 const en: Translations = {
@@ -34,6 +48,7 @@ const en: Translations = {
     ariaLabel: 'Main navigation',
     calendar: 'Calendar',
     settings: 'Settings',
+    guide: 'Guide',
   },
   calendar: {
     previousMonth: 'Previous month',
@@ -56,6 +71,20 @@ const en: Translations = {
     '8 days a month',
     '10 days a month',
   ],
+  guide: {
+    heading: 'Guide',
+    description:
+      'Bodhi Calendar helps Vietnamese Buddhists who practice intermittent vegetarianism keep track of which days to eat vegetarian. It shows both the Gregorian (solar) date and the Vietnamese lunar date side by side, so you never have to convert between calendars yourself.',
+    howToRead: 'How to read a date cell',
+    examples: {
+      regular: 'A regular day. The small number at the top is the lunar date; the larger number below is the solar date.',
+      vegetarian: 'A vegetarian day. Shown in green with a dot above. Observe the lunar date to confirm it is one of your practice days.',
+      todayNormal: 'Today — not a vegetarian day. Highlighted with a filled circle so it is easy to spot at a glance.',
+      todayVegetarian: 'Today — and a vegetarian day. The green filled circle means both: today, and a day to eat vegetarian.',
+      otherMonth: 'A day from the previous or next month, shown faded for context.',
+    },
+    settingsNote: 'Which days are marked as vegetarian depends on your practice. Practitioners observe anywhere from 2 to 10 vegetarian days per lunar month. You can select your practice in the Settings tab.',
+  },
 };
 
 const nb: Translations = {
@@ -66,6 +95,7 @@ const nb: Translations = {
     ariaLabel: 'Hovednavigasjon',
     calendar: 'Kalender',
     settings: 'Innstillinger',
+    guide: 'Guide',
   },
   calendar: {
     previousMonth: 'Forrige måned',
@@ -88,6 +118,20 @@ const nb: Translations = {
     '8 dager i måneden',
     '10 dager i måneden',
   ],
+  guide: {
+    heading: 'Guide',
+    description:
+      'Bodhi Calendar hjelper vietnamesiske buddhister som praktiserer intermittent vegetarianisme å holde oversikt over hvilke dager de skal spise vegetarisk. Den viser både gregoriansk dato og vietnamesisk månedsdato side om side, slik at du aldri trenger å konvertere mellom kalendere selv.',
+    howToRead: 'Slik leser du en datocelle',
+    examples: {
+      regular: 'En vanlig dag. Det lille tallet øverst er månedsdatoen; det større tallet nedenfor er den gregorianske datoen.',
+      vegetarian: 'En vegetardag. Vist i grønt med en prikk over. Se på månedsdatoen for å bekrefte at det er en av dine praksisdager.',
+      todayNormal: 'I dag — ikke en vegetardag. Fremhevet med en fylt sirkel slik at den er lett å se med et blikk.',
+      todayVegetarian: 'I dag — og en vegetardag. Den grønne sirkelen betyr begge deler: i dag, og en dag for å spise vegetarisk.',
+      otherMonth: 'En dag fra forrige eller neste måned, vist nedtonet for kontekst.',
+    },
+    settingsNote: 'Hvilke dager som markeres som vegetardager avhenger av din praksis. Praktiserende observerer mellom 2 og 10 vegetardager i måneden. Du kan velge din praksis i Innstillinger-fanen.',
+  },
 };
 
 const vi: Translations = {
@@ -98,6 +142,7 @@ const vi: Translations = {
     ariaLabel: 'Điều hướng chính',
     calendar: 'Lịch',
     settings: 'Cài đặt',
+    guide: 'Hướng dẫn',
   },
   calendar: {
     previousMonth: 'Tháng trước',
@@ -120,6 +165,20 @@ const vi: Translations = {
     '8 ngày một tháng',
     '10 ngày một tháng',
   ],
+  guide: {
+    heading: 'Hướng dẫn',
+    description:
+      'Bodhi Calendar giúp các Phật tử người Việt thực hành ăn chay kỳ theo dõi những ngày cần ăn chay. Ứng dụng hiển thị cả ngày dương lịch lẫn ngày âm lịch Việt Nam song song, giúp bạn không cần tự đổi lịch.',
+    howToRead: 'Cách đọc ô ngày',
+    examples: {
+      regular: 'Ngày thường. Số nhỏ phía trên là ngày âm lịch; số lớn phía dưới là ngày dương lịch.',
+      vegetarian: 'Ngày chay. Hiển thị màu xanh lá với dấu chấm phía trên. Xem ngày âm để xác nhận đây là một trong các ngày chay của bạn.',
+      todayNormal: 'Hôm nay — không phải ngày chay. Được đánh dấu bằng vòng tròn đặc để dễ nhận biết.',
+      todayVegetarian: 'Hôm nay — và là ngày chay. Vòng tròn xanh lá có nghĩa là: hôm nay, đồng thời là ngày cần ăn chay.',
+      otherMonth: 'Ngày thuộc tháng trước hoặc tháng sau, hiển thị mờ để tham khảo.',
+    },
+    settingsNote: 'Những ngày nào được đánh dấu là ngày chay phụ thuộc vào thực hành của bạn. Người thực hành có thể giữ chay từ 2 đến 10 ngày mỗi tháng âm. Bạn có thể chọn thực hành của mình trong tab Cài đặt.',
+  },
 };
 
 const TRANSLATIONS: Record<LocaleTag, Translations> = { 'en-US': en, nb, vi };

--- a/src/pages/Calendar/Calendar.tsx
+++ b/src/pages/Calendar/Calendar.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames';
 import {
   addMonths,
   format,
@@ -12,6 +11,7 @@ import { useState } from 'react';
 import useSWR from 'swr';
 
 import { Button } from '@/components/Button';
+import { DayCellView } from '@/components/DayCellView';
 import { resolveTranslations, Translations } from '@/data/i18n';
 import { AppLocale, resolveLocale } from '@/data/locale';
 import { resolveSettings } from '@/data/settings';
@@ -170,8 +170,9 @@ function DayCell({ day, currentMonth, vegetarianPractice, locale, t }: DayCellPr
     ? vegetarianPractice.for30DayMonths
     : vegetarianPractice.for29DayMonths;
 
-  const isCurrentMonth = getMonth(day) === currentMonth;
+  const isTodayDay = isToday(day);
   const isVegetarianDay = vegetarianDays.includes(lunarDate.lunarDay);
+
   const label = [
     format(day, t.dateFormat, { locale: locale.dateFnsLocale }),
     t.lunarDay(lunarDate.lunarDay),
@@ -179,22 +180,15 @@ function DayCell({ day, currentMonth, vegetarianPractice, locale, t }: DayCellPr
   ]
     .filter(Boolean)
     .join(', ');
+
   return (
-    <div className="flex justify-center">
-      <div
-        aria-label={label}
-        className={classNames(
-          'relative flex flex-col justify-center items-center w-[2.2em] h-[2.2em]',
-          isToday(day) && !isVegetarianDay && 'bg-(--foreground) rounded-full font-bold text-(--background)',
-          isToday(day) && isVegetarianDay && 'bg-(--vegetarian) rounded-full font-bold text-(--background)',
-          !isCurrentMonth && 'opacity-[0.5]',
-          isVegetarianDay && !isToday(day) && 'text-(--vegetarian) font-bold',
-        )}
-      >
-        {isVegetarianDay && <span aria-hidden="true" className="absolute top-[0.3em] text-[0.3em] leading-none">•</span>}
-        <span className="text-[0.5em] leading-none">{lunarDate.lunarDay}</span>
-        <span className="leading-none">{getDate(day)}</span>
-      </div>
-    </div>
+    <DayCellView
+      lunarDay={lunarDate.lunarDay}
+      solarDay={getDate(day)}
+      isToday={isTodayDay}
+      isVegetarian={isVegetarianDay}
+      faded={getMonth(day) !== currentMonth}
+      aria-label={label}
+    />
   );
 }

--- a/src/pages/Guide.tsx
+++ b/src/pages/Guide.tsx
@@ -1,0 +1,49 @@
+import { DayCellView } from '@/components/DayCellView';
+import { Translations } from '@/data/i18n';
+
+type GuideProps = {
+  t: Translations;
+};
+
+export function Guide({ t }: GuideProps) {
+  const g = t.guide;
+
+  return (
+    <div className="max-w-[420px] m-auto">
+      <h1 className="text-4xl text-center font-bold mb-4">{g.heading}</h1>
+      <p className="mb-6 leading-relaxed">{g.description}</p>
+
+      <h2 className="text-xl font-bold mb-4">{g.howToRead}</h2>
+
+      <div className="flex flex-col gap-6">
+        <ExampleRow label={g.examples.regular} lunarDay={12} solarDay={5} />
+        <ExampleRow label={g.examples.vegetarian} lunarDay={15} solarDay={13} isVegetarian />
+        <ExampleRow label={g.examples.todayNormal} lunarDay={3} solarDay={21} isToday />
+        <ExampleRow label={g.examples.todayVegetarian} lunarDay={1} solarDay={28} isToday isVegetarian />
+        <ExampleRow label={g.examples.otherMonth} lunarDay={9} solarDay={31} faded />
+      </div>
+
+      <p className="mt-6 leading-relaxed">{g.settingsNote}</p>
+    </div>
+  );
+}
+
+type ExampleRowProps = {
+  label: string;
+  lunarDay: number;
+  solarDay: number;
+  isToday?: boolean;
+  isVegetarian?: boolean;
+  faded?: boolean;
+};
+
+function ExampleRow({ label, lunarDay, solarDay, isToday, isVegetarian, faded }: ExampleRowProps) {
+  return (
+    <div className="flex items-center gap-4">
+      <div className="flex-shrink-0" style={{ fontSize: 'calc(1rem + 1vw)', width: '2.2em' }}>
+        <DayCellView lunarDay={lunarDay} solarDay={solarDay} isToday={isToday} isVegetarian={isVegetarian} faded={faded} />
+      </div>
+      <p className="text-sm leading-snug flex-1">{label}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a Guide tab explaining what Bodhi Calendar is for and how to read
it. The page includes a short description and a visual legend showing all
five date cell variants (regular, vegetarian, today, today+vegetarian,
other-month). Also mentions the Settings tab and vegetarian practice
selection. Translations provided for English, Norwegian, and Vietnamese.

Refactors DayCell into a smart component (computes isToday/isVegetarian)
and a dumb DayCellView (renders from props), so the Guide can reuse the
same rendering logic without duplication.

New users see a green badge dot on the Guide tab until they visit it for
the first time, persisted via localStorage.

https://claude.ai/code/session_01FqFefEz37gvr1vdVQRm65R